### PR TITLE
Implement event subscription hook

### DIFF
--- a/frontend/app/components/eventCard.tsx
+++ b/frontend/app/components/eventCard.tsx
@@ -2,10 +2,18 @@ import { getEventTypes, type EventType } from "~/lib/event";
 import { Card, CardContent } from "./ui/card";
 import { Badge } from "./ui/badge";
 import { Calendar, MapPin } from "lucide-react";
-import { Link } from "react-router";
 import { Button } from "./ui/button";
+import { useAuth } from "./auth/AuthContext";
+import { useCreateSubscription } from "~/lib/eventSubscription";
 
 export function EventCard({ event }: { event: EventType }) {
+    const { isAuthenticated } = useAuth();
+    const mutation = useCreateSubscription();
+
+    const handleSubscribe = () => {
+        mutation.mutate(event.id);
+    };
+
     return (
         <Card className="overflow-hidden hover:shadow-lg transition-shadow bg-white">
             <div className="aspect-video relative">
@@ -48,11 +56,16 @@ export function EventCard({ event }: { event: EventType }) {
                     {event.subscriptions_count > 1 ? "s" : ""}
                 </span>
             </div>
-            <Link to="/signup">
-                <Button size="sm" className="w-full bg-royal-blue-600 hover:bg-royal-blue-700">
-                S'inscrire
+            {isAuthenticated && (
+                <Button
+                    size="sm"
+                    className="w-full bg-royal-blue-600 hover:bg-royal-blue-700"
+                    onClick={handleSubscribe}
+                    disabled={mutation.isPending}
+                >
+                    {mutation.isPending ? '...': "S'inscrire"}
                 </Button>
-            </Link>
+            )}
             </CardContent>
         </Card>
     )

--- a/frontend/app/lib/eventSubscription.ts
+++ b/frontend/app/lib/eventSubscription.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { getCSRFToken } from "./django";
+
+export const AnswerEnum = z.enum(["YES", "NO", "MAYBE"]);
+
+export const EventSubscribeActionSchema = z.object({
+  id: z.number(),
+  answer: AnswerEnum,
+  can_invite: z.boolean(),
+});
+export type EventSubscribeAction = z.infer<typeof EventSubscribeActionSchema>;
+
+type CreateSubscriptionData = Partial<Omit<EventSubscribeAction, 'id'>>;
+
+export async function createSubscription(eventId: number, data: CreateSubscriptionData = { answer: 'YES', can_invite: true }): Promise<EventSubscribeAction> {
+  const resp = await fetch(`/api/event/events/${eventId}/subscribe/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCSRFToken() || '',
+    },
+    body: JSON.stringify(data),
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create subscription');
+  }
+  const json = await resp.json();
+  return EventSubscribeActionSchema.parse(json);
+}
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+export function useCreateSubscription() {
+  return useMutation({
+    mutationFn: (eventId: number) => createSubscription(eventId),
+    onSuccess: () => {
+      toast.success("Inscription enregistrée");
+    },
+    onError: () => {
+      toast.error("Erreur lors de l'inscription");
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add `createSubscription` API helper and TanStack Query mutation hook
- show event card signup button only when authenticated
- call the new mutation on signup button

## Testing
- `bun run typecheck` *(fails: cannot find some names and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855b3d08e1c8332be058ccda0e579ac