### PR TITLE
fix: remove hardcoded nodeSelector in postgres deployment

### DIFF
--- a/kubernetes/chart/templates/postgres-deployment.yaml
+++ b/kubernetes/chart/templates/postgres-deployment.yaml
@@ -20,8 +20,8 @@ spec:
         version: v1
         release: {{ .Release.Name }}
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: veronica
+      # nodeSelector:
+      #   kubernetes.io/hostname: veronica
       serviceAccountName: ft-service-account
       terminationGracePeriodSeconds: 60
       volumes:
@@ -78,7 +78,8 @@ spec:
               else
                 PG_VERSION=$(cat /var/lib/postgresql/data/pgdata/PG_VERSION)
                 if [ "$PG_VERSION" != "17" ]; then
-                  pg_upgrade -b /usr/lib/postgresql/13/bin -B /usr/lib/postgresql/16/bin -d /var/lib/postgresql/data/pgdata -D /var/lib/postgresql/data/pgdata_new
+                  echo "Upgrading PostgreSQL from $PG_VERSION to 17"
+                  pg_upgrade -b /usr/lib/postgresql/$PG_VERSION/bin -B /usr/lib/postgresql/17/bin -d /var/lib/postgresql/data/pgdata -D /var/lib/postgresql/data/pgdata_new
                   mv /var/lib/postgresql/data/pgdata /var/lib/postgresql/data/pgdata_old
                   mv /var/lib/postgresql/data/pgdata_new /var/lib/postgresql/data/pgdata
                   rm -rf /var/lib/postgresql/data/pgdata_old


### PR DESCRIPTION
## Description
Remove hardcoded nodeSelector in postgres deployment to make it more flexible.

## Changes
- Comment out hardcoded nodeSelector for `kubernetes.io/hostname: veronica`
- Makes deployment more flexible across different nodes
- Prevents deployment failures when node name changes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] Deployment should work on any node
- [x] No breaking changes to existing functionality