### PR TITLE
fix: correct PostgreSQL upgrade script version handling

### DIFF
--- a/kubernetes/chart/templates/postgres-deployment.yaml
+++ b/kubernetes/chart/templates/postgres-deployment.yaml
@@ -78,7 +78,8 @@ spec:
               else
                 PG_VERSION=$(cat /var/lib/postgresql/data/pgdata/PG_VERSION)
                 if [ "$PG_VERSION" != "17" ]; then
-                  pg_upgrade -b /usr/lib/postgresql/13/bin -B /usr/lib/postgresql/16/bin -d /var/lib/postgresql/data/pgdata -D /var/lib/postgresql/data/pgdata_new
+                  echo "Upgrading PostgreSQL from $PG_VERSION to 17"
+                  pg_upgrade -b /usr/lib/postgresql/$PG_VERSION/bin -B /usr/lib/postgresql/17/bin -d /var/lib/postgresql/data/pgdata -D /var/lib/postgresql/data/pgdata_new
                   mv /var/lib/postgresql/data/pgdata /var/lib/postgresql/data/pgdata_old
                   mv /var/lib/postgresql/data/pgdata_new /var/lib/postgresql/data/pgdata
                   rm -rf /var/lib/postgresql/data/pgdata_old


### PR DESCRIPTION
## Description
Fix PostgreSQL upgrade script to use dynamic version handling instead of hardcoded versions.

## Changes
- Use dynamic `$PG_VERSION` variable instead of hardcoded 13->16 upgrade
- Add logging for upgrade process visibility
- Fixes upgrade script that was checking for version 17 but upgrading from 13

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] Upgrade script now works with any PostgreSQL version
- [x] Added logging for better debugging