### PR TITLE
fix: enable Istio sidecar on frontend for mTLS

### DIFF
--- a/kubernetes/chart/templates/destinationrule.yaml
+++ b/kubernetes/chart/templates/destinationrule.yaml
@@ -7,7 +7,7 @@ spec:
   host: ft-frontend
   trafficPolicy:
     tls:
-      mode: DISABLE
+      mode: ISTIO_MUTUAL
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/kubernetes/chart/templates/frontend-deployment.yaml
+++ b/kubernetes/chart/templates/frontend-deployment.yaml
@@ -20,8 +20,10 @@ spec:
       labels:
         app: ft-frontend
         version: v1
+        sidecar.istio.io/inject: "true"
       annotations:
-        sidecar.istio.io/inject: "false"
+        proxy.istio.io/config: '{"holdApplicationUntilProxyStarts": true}'
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       imagePullSecrets:
         - name: ghcr-secret
@@ -37,6 +39,8 @@ spec:
           ports:
             - containerPort: 80
               name: http
+            - containerPort: 15020
+              name: http-istio
           volumeMounts:
             - name: nginx-run
               mountPath: /run/nginx

--- a/kubernetes/chart/templates/frontend-service.yaml
+++ b/kubernetes/chart/templates/frontend-service.yaml
@@ -10,5 +10,8 @@ spec:
   - port: 80
     name: http
     targetPort: 80
+  - port: 15020
+    name: http-istio
+    targetPort: 15020
   selector:
     app: ft-frontend


### PR DESCRIPTION
## Description
Enable Istio sidecar on frontend deployment to ensure mTLS communication.

## Changes
- Enable Istio sidecar injection on frontend deployment
- Add proxy configuration annotations for proper startup
- Add Istio port 15020 to frontend service
- Update DestinationRule to use ISTIO_MUTUAL instead of DISABLE
- Ensures mTLS communication between frontend and backend

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] Frontend should have Istio sidecar injected
- [x] mTLS should be enabled between frontend and backend